### PR TITLE
skills: add performance testing guidelines

### DIFF
--- a/configuration/agents/skills/performance/SKILL.md
+++ b/configuration/agents/skills/performance/SKILL.md
@@ -8,7 +8,7 @@ description: "Performance testing: whether the system meets its performance obje
 Performance testing measures whether the system meets its performance objectives under realistic
 conditions: the latency a caller sees, the throughput it sustains, and how it behaves as load
 rises. It sits off the unit pyramid. It exercises the whole running system under load, so it runs
-against a deployed system, slow and broad, on its own schedule.
+against a deployed system, slow and broad.
 
 ## Kinds of test
 

--- a/configuration/agents/skills/performance/SKILL.md
+++ b/configuration/agents/skills/performance/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: performance
+description: "Performance testing: whether the system meets its performance objectives under realistic load. Covers the kinds of test (load, stress, soak, spike), what to measure (latency percentiles, throughput, saturation, error rate), the tie to service-level objectives, and code-level micro-benchmarks. Use this when checking whether a change holds up under load, sizing capacity, choosing which performance signal to measure, or benchmarking a hot path. For gating a measurement as a regression test, see the `testing` skill's performance.md."
+---
+
+# Performance testing
+
+Performance testing measures whether the system meets its performance objectives under realistic
+conditions: the latency a caller sees, the throughput it sustains, and how it behaves as load
+rises. It sits off the unit pyramid. It exercises the whole running system under load, so it runs
+against a deployed system, slow and broad, on its own schedule.
+
+## Kinds of test
+
+Each kind puts the system under a different load shape and answers a different question:
+
+- **Load**: the expected peak load, held steady. Does the system meet its objectives under the
+  traffic it is built for?
+- **Stress**: load pushed past the expected peak until something gives. Where is the limit, and
+  how does the system behave when it reaches it?
+- **Soak (endurance)**: a moderate load held for hours or days. Does a slow leak or drift appear
+  that a short run hides, such as growing memory or a filling connection pool?
+- **Spike**: a sudden jump from low to high load. Does the system absorb the surge and recover
+  afterward?
+
+## What to measure
+
+Measure the signal a caller feels, at the edge where they enter:
+
+- **Latency** as percentiles. Report p50, p95, and p99. An average hides the tail, and the tail is
+  what a fraction of users experience on every request.
+- **Throughput**: requests or operations completed per unit of time at a given load.
+- **Saturation**: how full the constrained resource is (the pool, the queue, the CPU, the disk),
+  which predicts where the next limit will fall.
+- **Error rate under load**: the share of requests that fail as load rises. A system that stays
+  fast by shedding requests is still failing its objective.
+
+These are the golden signals under deliberate load. The `observability` skill covers capturing
+them in production; a performance test drives them on demand before a change ships.
+
+## Tie to service-level objectives
+
+A performance objective is meaningful once it is stated as a target: a latency percentile or a
+success rate over a window. That target is a service-level objective, defined in the
+`observability` skill. A performance test validates the objective before production, so a
+regression surfaces in a test run before the error budget burns down. State the objective first,
+then measure against it.
+
+## Micro-benchmarks
+
+A micro-benchmark measures one function or one hot path in isolation. It answers a narrower
+question than a load test: is this specific piece of code fast enough, and did a change make it
+slower?
+
+Micro-benchmarks are easy to get wrong. Guard against the common faults:
+
+- **Warm-up**: a runtime with a JIT or a cold cache is slow on its first iterations. Discard the
+  warm-up and measure the steady state.
+- **Dead-code elimination**: a compiler that sees an unused result can delete the work being
+  timed. Consume the result so the work survives optimization.
+- **Isolation**: build the input outside the timed region and measure the one operation under
+  test, so the number reflects the operation and not its setup.
+
+Pin a micro-benchmark against a baseline, the same way a system-level test is pinned, so a
+regression is caught by comparison. The `testing` skill's `performance.md` covers baselines and
+gating a comparison in CI.

--- a/configuration/agents/skills/testing/SKILL.md
+++ b/configuration/agents/skills/testing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: testing
-description: "Testing strategies around the unit loop and where each fits: acceptance tests driven from outside through real adapters, consumer-driven contract tests at the ports, test data builders and deterministic fixtures, and property-based testing over generated inputs. Use this when deciding how to test a change beyond a single unit test, covering a feature end to end, a service boundary, the data a test needs, or an invariant over many inputs. Routes to a detail file per strategy. Complements the `tdd` skill, which owns the red-green-refactor unit loop."
+description: "Testing strategies around the unit loop and where each fits: acceptance tests driven from outside through real adapters, consumer-driven contract tests at the ports, test data builders and deterministic fixtures, property-based testing over generated inputs, and performance tests gated against a baseline. Use this when deciding how to test a change beyond a single unit test, covering a feature end to end, a service boundary, the data a test needs, an invariant over many inputs, or whether a change holds up under load. Routes to a detail file per strategy. Complements the `tdd` skill, which owns the red-green-refactor unit loop."
 ---
 
 # Testing strategies
@@ -19,6 +19,10 @@ The strategies sit on a pyramid, against the boundary between the domain and its
 - **Contract tests** sit at the outbound seams, where the system meets another service across a
   port. They pin the interaction without a full end-to-end. See `contract.md`.
 
+**Performance tests** sit off this pyramid. They are a non-functional gate that runs the whole
+system under load on its own schedule. See `performance.md` for gating one against a baseline, and
+the `performance` skill for the kinds of test and what to measure.
+
 Two strategies are techniques used inside tests at every level of the pyramid:
 
 - **Test data** builders and fixtures construct the values a test needs. See `test-data.md`.
@@ -28,7 +32,9 @@ Two strategies are techniques used inside tests at every level of the pyramid:
 
 The strategies stack. A test data builder constructs the input for a unit test, an acceptance
 test, and a property. A property can assert an invariant that a contract relies on. An acceptance
-test runs unit cycles on the inside while it stays red on the outside.
+test runs unit cycles on the inside while it stays red on the outside. A performance test drives
+the same inbound port an acceptance test uses, holding it under sustained load to measure latency
+and throughput.
 
 ## Routing
 
@@ -38,3 +44,4 @@ Read the detail file for the strategy in play:
 - `contract.md`: consumer-driven contracts at the outbound ports.
 - `test-data.md`: builders and factories, deterministic fixtures, anonymized data.
 - `property-based.md`: generated inputs, invariants, shrinking to a minimal case.
+- `performance.md`: performance tests as a gated regression check, baselines, deterministic runs.

--- a/configuration/agents/skills/testing/SKILL.md
+++ b/configuration/agents/skills/testing/SKILL.md
@@ -20,8 +20,8 @@ The strategies sit on a pyramid, against the boundary between the domain and its
   port. They pin the interaction without a full end-to-end. See `contract.md`.
 
 **Performance tests** sit off this pyramid. They are a non-functional gate that runs the whole
-system under load on its own schedule. See `performance.md` for gating one against a baseline, and
-the `performance` skill for the kinds of test and what to measure.
+system under load. See `performance.md` for gating one against a baseline, and the `performance`
+skill for the kinds of test and what to measure.
 
 Two strategies are techniques used inside tests at every level of the pyramid:
 

--- a/configuration/agents/skills/testing/performance.md
+++ b/configuration/agents/skills/testing/performance.md
@@ -7,9 +7,10 @@ measurements a gate.
 
 ## Where it sits
 
-A performance test is slow and broad. It runs the whole system under load, so it stays out of the
-fast unit suite that runs on every save. Run it on its own schedule, or on the changes that touch
-a performance-sensitive path, as a separate gate from the unit and acceptance suites.
+A performance test is slow and broad, so it stays out of the fast unit suite that runs on every
+save. A baseline comparison still belongs in a pull request: run it as a gate on the change, so a
+regression is caught before merge. Reserve the long-running tests, such as a multi-hour soak or a
+full-scale load run, for their own schedule.
 
 ## Baseline
 

--- a/configuration/agents/skills/testing/performance.md
+++ b/configuration/agents/skills/testing/performance.md
@@ -1,0 +1,45 @@
+# Performance testing
+
+Turn a performance measurement into a repeatable test: record a baseline, run it in a controlled
+environment, and fail the build when a change regresses past a threshold. The `performance` skill
+covers the kinds of performance test and what to measure. This file covers making one of those
+measurements a gate.
+
+## Where it sits
+
+A performance test is slow and broad. It runs the whole system under load, so it stays out of the
+fast unit suite that runs on every save. Run it on its own schedule, or on the changes that touch
+a performance-sensitive path, as a separate gate from the unit and acceptance suites.
+
+## Baseline
+
+A performance number means little on its own. Record a baseline: the measurement of the current
+system under a fixed load, kept in version control. Every later run compares against it, so a
+regression shows up as a change from a known-good reference. Update the baseline deliberately, in a
+reviewed change, once a new level is accepted as the norm.
+
+## A deterministic environment
+
+A comparison is valid only when the run that set the baseline and the run that checks against it
+differ in one thing: the code. Pin everything else.
+
+- Run on consistent, dedicated hardware whose neighbors do not move the result.
+- Warm up to steady state before measuring, so a cold cache or a JIT does not skew the first
+  samples.
+- Drive a controlled load profile: the same request mix, rate, and duration each run.
+- Seed the data to a fixed size and shape, so the database the test hits is the same every time.
+
+An uncontrolled environment produces numbers that move on their own, and a gate built on them
+blocks good changes or passes bad ones.
+
+## Gating in CI
+
+Compare the run against the baseline and fail the build when it regresses past a threshold:
+
+- Compare percentiles, so the tail is gated as well as the median.
+- Allow for variance. A performance run has noise, so take several runs and compare a statistic: a
+  median of runs, or a bound that accounts for the spread. Set the threshold wider than the noise,
+  so a real regression trips the gate and ordinary jitter stays under it.
+- Report the number on a pass, so a slow drift toward the threshold is visible before it trips.
+
+For the service-level objectives a gate defends, see the `observability` skill.


### PR DESCRIPTION
Adds performance testing guidance to the shared agent skills, split into two artifacts with a clean boundary so they do not duplicate each other.

## New `performance` skill

`configuration/agents/skills/performance/SKILL.md` owns the subject matter:

- Kinds of test: load, stress, soak, spike.
- What to measure: latency percentiles, throughput, saturation, error rate under load.
- Tie to service-level objectives, cross-referencing the `observability` skill.
- Code-level micro-benchmarks and their common pitfalls.

Single `SKILL.md` like the `observability` skill, tool-agnostic, discovered by frontmatter and picked up by `configure_agents.sh`'s glob.

## New `testing/performance.md` detail file

Owns the testing and CI discipline: turning a measurement into a gated regression test through a baseline, a deterministic production-like environment, and a CI gate on percentiles with variance handling. Wired into `testing/SKILL.md` (frontmatter, an off-pyramid note, a composition line, and a routing entry).
