### PR TITLE
deliver: make the pull request the only in-flight surface

### DIFF
--- a/configuration/agents/skills/deliver/SKILL.md
+++ b/configuration/agents/skills/deliver/SKILL.md
@@ -13,11 +13,10 @@ test-driven loop from the `tdd` skill to done.
 ## In-flight surface
 
 The in-flight surface holds the contract while the branch is live: the test list with each
-item's state, the decision log, and the open questions. By default it is the pull request, with
-the test list as a checklist in the body and the decision log in comments. When the repository
-has no remote, it is a local `PLAN.md` at the repo root, gitignored. A repository may override
-the surface in its own agent instructions (`AGENTS.md` or `CLAUDE.md`); the override owns where
-state and the log live.
+item's state, the decision log, and the open questions. It is the pull request: the test list
+is a checklist in the PR body, and the decision log and open questions live in the body or in
+comments. A repository may override the surface in its own agent instructions (`AGENTS.md` or
+`CLAUDE.md`); the override owns where state and the log live.
 
 Durable decisions, the ones a future reader will need the reasoning for, graduate into ADRs in
 `docs/adr/` (see the `adr` skill). They outlive the branch.
@@ -31,8 +30,7 @@ follow-up cycle once the trigger fires.
 
 ## 0. Resume check
 
-Look for an existing in-flight surface for this branch (the open pull request, or `PLAN.md` at
-the repo root). If one exists, this is a resume:
+Look for an open pull request for this branch. If one exists, this is a resume:
 
 1. Read it: the goal, the test list with each item's state, the decision log, the open questions.
 2. Run the repository's verification to confirm the real state of the code.
@@ -40,7 +38,7 @@ the repo root). If one exists, this is a resume:
    diverge (the plan marks an item done but its test is red, or passing work is unrecorded),
    stop and surface the divergence rather than guessing.
 
-With no in-flight surface yet, start fresh below.
+With no open pull request yet, start fresh below.
 
 ## 1. Clarify
 
@@ -64,21 +62,27 @@ With the plan agreed, turn it into an ordered **test list**:
 
 Present the list and halt. The approved list is the contract. Hold here until the human approves it.
 
-On approval, record the contract on the in-flight surface:
+On approval, create the branch for the change and push it. The pull request that holds the
+contract is opened after the first green cycle, once a commit exists to open it against (see
+step 4). Until then, keep the approved contract ready to write into the PR body:
 
 - The goal.
 - The ordered test list, each item marked pending or done.
 - A decision log: the choices made during Clarify and their reasons. Append-only.
 - Open questions: anything that triggered a stop and awaits an answer.
 
-The in-flight surface is how state survives a session boundary. Treat it as part of the work.
+The pull request is how state survives a session boundary. Treat it as part of the work.
 
 ## 4. Drive
 
 Work the list top to bottom, one item per cycle. Each cycle follows the `tdd` skill: red,
 green, refactor, then run the repository's verification.
 
-After each green cycle, update the in-flight surface: mark the item done and record any decision
+After the first green cycle a commit exists on the branch: open the draft pull request with
+`gh pr create --draft --assignee @me` and write the contract into its body (the goal, the test
+list as a checklist, the decision log, the open questions).
+
+After each green cycle, update the pull request: mark the item done and record any decision
 or learning. Append scope-refining tests to the list and keep going. On a scope-expanding
 behavior, stop and bring the proposed items back for approval. Flag any decision that clears the
 ADR bar (see the `adr` skill) as you record it.
@@ -90,6 +94,5 @@ List empty and verification green:
 - Graduate the flagged decisions into `docs/adr/` as ADRs (see the `adr` skill), committed on
   the branch so they merge to trunk.
 - Hand to CI, the release gate.
-- The in-flight surface is discarded with the branch. A pull request's checklist and log stay
-  on the PR, and a local `PLAN.md` is deleted. Neither is committed, so trunk carries only the
-  code and its ADRs once the work ships.
+- The pull request's checklist and log stay on the PR; they are never committed, so trunk
+  carries only the code and its ADRs once the work ships.


### PR DESCRIPTION
## Goal
Stop `deliver` defaulting to PLAN.md. Prescribe a concrete PR-based flow: branch → push → draft PR assigned to @me → plan lives in the PR body. PR becomes the only in-flight surface.

## Test list (contract)
- [x] In-flight surface redefined as the pull request; PLAN.md / no-remote fallback removed
- [x] Resume check looks for an open PR for the branch
- [x] Step 3 creates + pushes the branch on approval, no PR/empty commit yet
- [x] Step 4 opens the draft PR (`gh pr create --draft --assignee @me`) after the first green cycle
- [x] Step 5 drops the PLAN.md deletion clause

## Decision log
- Assignee: `@me` (portable; gh resolves to the authenticated user) over a literal handle.
- PR opens after the first green cycle, no empty commit; accepts that the plan lives only in the conversation for that first cycle.
- PLAN.md removed entirely; the skill assumes a remote always exists.
- "in-flight surface" kept as the concept name (the `adr` skill also uses it); only its definition in `deliver` changed.

## Open questions
None.